### PR TITLE
Dockerfiles and compose definitions for pinpoint-editor and postgres

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 node_modules/
 .sass-cache/
+bower_components/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM node:8-alpine
+
+RUN apk add --no-cache tini
+
+EXPOSE 3001
+
+WORKDIR /usr/src/app
+
+# Copy just the package*.json files to perform the install
+COPY package* ./
+RUN npm install
+
+# Then copy the remaining ones. Splitting the install from the main copy lets us cache the results of the install
+# between code changes
+COPY . .
+
+# Node wasn't designed to be run as PID 1. Tini is a tiny init wrapper.
+ENTRYPOINT ["/sbin/tini", "--"]
+
+CMD ["npm", "start"]

--- a/Dockerfile.postgres
+++ b/Dockerfile.postgres
@@ -1,0 +1,2 @@
+FROM postgres
+COPY ./build/migrate.sql /docker-entrypoint-initdb.d/

--- a/README.md
+++ b/README.md
@@ -79,6 +79,11 @@ Here's how to install it locally:
 
     You will then be able to access Pinpoint at [http://localhost:3001](http://localhost:3001/).
 
+## Docker setup
+
+If you have Docker installed you can run the Pinpoint editor by simply typing `docker-compose up`. You can
+then access Pinpoint at [http://localhost:3001](http://localhost:3001/).
+
 ## Architecture
 
 On the server, Pinpoint uses the minimal Express framework for routing. Data is stored as JSON using [PostgresSQL's native JSON data type](http://schinckel.net/2014/05/25/querying-json-in-postgres/), which can then be accessed via a simple API (see below for details). Data can then be exported to S3-hosted static JSON for production use.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3'
+services:
+    postgres:
+        build:
+            context: .
+            dockerfile: ./Dockerfile.postgres
+    pinpoint:
+        build: .
+        environment:
+            - DATABASE_URL=postgresql://postgres@postgres/postgres
+        ports:
+            - "3001:3001"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "server.js",
   "author": "ejb <mail@elliotbentley.com>",
   "scripts": {
-    "start": "node server.js"
+    "start": "node server.js",
+    "postinstall": "bower install"
   },
   "dependencies": {
     "body-parser": "~1.5.2",
@@ -19,10 +20,11 @@
     "pug": "^2.0.0-beta10"
   },
   "devDependencies": {
-    "karma": "~0.12.31",
+    "bower": "^1.8.4",
     "jasmine-core": "~2.2.0",
-    "karma-jasmine": "~0.3.5",
+    "karma": "~0.12.31",
     "karma-chrome-launcher": "~0.1.7",
+    "karma-jasmine": "~0.3.5",
     "karma-phantomjs-launcher": "~0.1.4"
   }
 }


### PR DESCRIPTION
To avoid needing to install postgres on your local machine adds in a docker-compose file and related Dockerfile definitions that starts up the pinpoint service as well as the postgres database it uses to store the maps.